### PR TITLE
Tests: Plugin and readme header validation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 Self hosted Twemoji images
 
+[![PHP Unit Tests](https://github.com/peterwilsoncc/local-twemoji/actions/workflows/phpunit.yaml/badge.svg)](https://github.com/peterwilsoncc/local-twemoji/actions/workflows/phpunit.yaml) [![Coding Standards](https://github.com/peterwilsoncc/local-twemoji/actions/workflows/coding-standards.yaml/badge.svg)](https://github.com/peterwilsoncc/local-twemoji/actions/workflows/coding-standards.yaml)
+
 ## Description
 
 Local Twemoji is a WordPress plugin to serve fallback emoji images from your own site URL rather than the WordPress.org CDN.

--- a/tests/class-test-plugin-headers.php
+++ b/tests/class-test-plugin-headers.php
@@ -166,6 +166,11 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 		$plugin_header = self::$defined_plugin_headers[ $plugin_header_name ];
 		$readme_header = self::$defined_readme_headers[ $readme_header_name ?? $plugin_header_name ];
 
+		if ( empty( $plugin_header ) || empty( $readme_header ) ) {
+			$this->markTestSkipped( "The header {$plugin_header_name} is not defined in both the readme and plugin file." );
+			return;
+		}
+
 		$this->assertSame( $plugin_header, $readme_header, "The header {$plugin_header_name} does not match between the readme and plugin file." );
 	}
 
@@ -175,14 +180,15 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	 * @return array[] Data provider.
 	 */
 	public function data_common_headers_match() {
+		// Can't use the defined headers as they are not defined until after this is called.
 		$common_headers = array_intersect_key(
-			self::$defined_readme_headers,
-			self::$defined_plugin_headers
+			self::$readme_headers,
+			self::$plugin_headers
 		);
 
 		$headers = array();
 		// Always test the version matches the stable tag.
-		$headers[] = array( 'Version', 'Stable tag' );
+		$headers['Stable Tag'] = array( 'Version', 'Stable tag' );
 
 		foreach ( $common_headers as $header => $value ) {
 			$headers[ $header ] = array( $header );

--- a/tests/class-test-plugin-headers.php
+++ b/tests/class-test-plugin-headers.php
@@ -145,8 +145,8 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	public function data_required_readme_headers() {
 		$required_headers = array_filter(
 			self::$readme_headers,
-			function ( $required ) {
-				return REQUIRED === $required;
+			function ( $status ) {
+				return REQUIRED === $status;
 			}
 		);
 		$headers          = array();
@@ -175,8 +175,8 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	public function data_forbidden_readme_headers() {
 		$forbidden_headers = array_filter(
 			self::$readme_headers,
-			function ( $required ) {
-				return FORBIDDEN === $required;
+			function ( $status ) {
+				return FORBIDDEN === $status;
 			}
 		);
 		$headers           = array();
@@ -206,8 +206,8 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	public function data_required_plugin_headers() {
 		$required_headers = array_filter(
 			self::$plugin_headers,
-			function ( $required ) {
-				return REQUIRED === $required;
+			function ( $status ) {
+				return REQUIRED === $status;
 			}
 		);
 		$headers          = array();
@@ -236,8 +236,8 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	public function data_forbidden_plugin_headers() {
 		$forbidden_headers = array_filter(
 			self::$plugin_headers,
-			function ( $required ) {
-				return FORBIDDEN === $required;
+			function ( $status ) {
+				return FORBIDDEN === $status;
 			}
 		);
 		$headers           = array();

--- a/tests/class-test-plugin-headers.php
+++ b/tests/class-test-plugin-headers.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Test Plugin Readme and PHP Headers
+ *
+ * @package PWCC\LocalTwemoji\Headers
+ */
+
+namespace PWCC\LocalTwemoji\Headers;
+
+use WP_UnitTestCase;
+
+/**
+ * Sample Tests
+ */
+class Test_Plugin_Headers extends WP_UnitTestCase {
+
+	/**
+	 * Readme headers specification
+	 *
+	 * @var string[] Headers defined in the readme spec. Key: Header, Value: true: required, false: optional.
+	 */
+	public static $readme_headers = array(
+		'Contributors'      => true,
+		'Donate link'       => false,
+		'Requires at least' => true, // Not required by the spec but I'm enforcing it.
+		'Tested up to'      => true,
+		'Stable tag'        => true,
+		'Requires PHP'      => false,
+		'License'           => true,
+		'License URI'       => false,
+	);
+
+	/**
+	 * Plugin headers specification
+	 *
+	 * @var string[] Headers defined in the plugin spec. Key: Header, Value: true: required, false: optional.
+	 */
+	public static $plugin_headers = array(
+		'Plugin Name'       => true,
+		'Plugin URI'        => false,
+		'Description'       => true,
+		'Version'           => true,
+		'Requires at least' => true, // Not required by the spec but I'm enforcing it.
+		'Requires PHP'      => true, // Not required by the spec but I'm enforcing it.
+		'Author'            => true,
+		'Author URI'        => false,
+		'License'           => true,
+		'License URI'       => false,
+		'Text Domain'       => false,
+		'Domain Path'       => false,
+		'Network'           => false,
+		'Update URI'        => false,
+		'Requires Plugins'  => false,
+	);
+
+	/**
+	 * Headers defined in the plugins readme.text file.
+	 *
+	 * @var string[] Headers defined in the readme spec Header => value.
+	 */
+	public static $defined_readme_headers = array();
+
+	/**
+	 * Headers defined in the plugin file.
+	 *
+	 * @var string[] Headers defined in the plugin spec Header => value.
+	 */
+	public static $defined_plugin_headers = array();
+
+	/**
+	 * Set up shared fixtures.
+	 */
+	public static function wpSetupBeforeClass() {
+		// Get the readme headers.
+		$readme_file_data = array();
+		foreach ( self::$readme_headers as $header => $required ) {
+			$readme_file_data[ $header ] = $header;
+		}
+		self::$defined_readme_headers = get_file_data(
+			__DIR__ . '/../readme.txt',
+			$readme_file_data
+		);
+		self::$defined_readme_headers = array_filter( self::$defined_readme_headers );
+
+		// Get the plugin headers.
+		// Plugin name.
+		$plugin_file_name = basename( dirname( __DIR__ ) ) . '.php';
+		if ( ! file_exists( __DIR__ . "/../{$plugin_file_name}" ) ) {
+			// Fallback to the generic plugin file name.
+			$plugin_file_name = 'plugin.php';
+		}
+
+		$plugin_file_data = array();
+		foreach ( self::$plugin_headers as $header => $required ) {
+			$plugin_file_data[ $header ] = $header;
+		}
+
+		self::$defined_plugin_headers = get_file_data(
+			__DIR__ . "/../{$plugin_file_name}",
+			$plugin_file_data
+		);
+		self::$defined_plugin_headers = array_filter( self::$defined_plugin_headers );
+	}
+
+	/**
+	 * Test that the readme file has all required headers.
+	 *
+	 * @dataProvider data_required_readme_headers
+	 *
+	 * @param string $header Header to test.
+	 */
+	public function test_required_readme_headers( $header ) {
+		$this->assertArrayHasKey( $header, self::$defined_readme_headers, "The readme file header {$header} is missing." );
+		$this->assertNotEmpty( self::$defined_readme_headers[ $header ], "The readme file header {$header} is empty." );
+	}
+
+	/**
+	 * Data provider for test_required_readme_headers.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_required_readme_headers() {
+		$required_headers = array_filter( self::$readme_headers );
+		$headers          = array();
+		foreach ( $required_headers as $header => $required ) {
+			$headers[ $header ] = array( $header );
+		}
+		return $headers;
+	}
+
+	/**
+	 * Test that the plugin file has all required headers.
+	 *
+	 * @dataProvider data_required_plugin_headers
+	 *
+	 * @param string $header Header to test.
+	 */
+	public function test_required_plugin_headers( $header ) {
+		$this->assertArrayHasKey( $header, self::$defined_plugin_headers, "The plugin file header {$header} is missing." );
+		$this->assertNotEmpty( self::$defined_plugin_headers[ $header ], "The readme file header {$header} is empty." );
+	}
+
+	/**
+	 * Data provider for test_required_plugin_headers.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_required_plugin_headers() {
+		$required_headers = array_filter( self::$plugin_headers );
+		$headers          = array();
+		foreach ( $required_headers as $header => $required ) {
+			$headers[ $header ] = array( $header );
+		}
+		return $headers;
+	}
+
+	/**
+	 * Test that headers defined in both the readme and plugin file match.
+	 *
+	 * Note: This test will show as skipped if there are no common headers defined in
+	 * both the readme and plugin file. This is fine.
+	 *
+	 * @dataProvider data_common_headers_match
+	 *
+	 * @param string $header Header to test.
+	 */
+	public function test_common_headers_match( $header ) {
+		$plugin_header = self::$defined_plugin_headers[ $header ];
+		$readme_header = self::$defined_readme_headers[ $header ];
+
+		$this->assertSame( $plugin_header, $readme_header, "The header {$header} does not match between the readme and plugin file." );
+	}
+
+	/**
+	 * Data provider for test_common_headers_match.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_common_headers_match() {
+		$common_headers = array_intersect_key(
+			self::$defined_readme_headers,
+			self::$defined_plugin_headers
+		);
+
+		$headers = array();
+		foreach ( $common_headers as $header => $value ) {
+			$headers[ $header ] = array( $header );
+		}
+		return $headers;
+	}
+}

--- a/tests/class-test-plugin-headers.php
+++ b/tests/class-test-plugin-headers.php
@@ -25,6 +25,7 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	 */
 	public static $readme_headers = array(
 		'Contributors'      => REQUIRED,
+		'Tags'              => OPTIONAL,
 		'Donate link'       => OPTIONAL,
 		'Requires at least' => REQUIRED, // Not required by the spec but I'm enforcing it.
 		'Tested up to'      => REQUIRED,
@@ -71,6 +72,7 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 
 		// Readme file headers that do not belong in the plugin file.
 		'Contributors'      => FORBIDDEN,
+		'Tags'              => FORBIDDEN,
 		'Donate link'       => FORBIDDEN,
 		'Tested up to'      => FORBIDDEN,
 		'Stable tag'        => FORBIDDEN,

--- a/tests/class-test-plugin-headers.php
+++ b/tests/class-test-plugin-headers.php
@@ -10,7 +10,7 @@ namespace PWCC\LocalTwemoji\Tests;
 use WP_UnitTestCase;
 
 /**
- * Sample Tests
+ * Test Plugin Readme and PHP Headers
  */
 class Test_Plugin_Headers extends WP_UnitTestCase {
 

--- a/tests/class-test-plugin-headers.php
+++ b/tests/class-test-plugin-headers.php
@@ -188,7 +188,7 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 
 		$headers = array();
 		// Always test the version matches the stable tag.
-		$headers['Stable Tag'] = array( 'Version', 'Stable tag' );
+		$headers['Stable tag matches version'] = array( 'Version', 'Stable tag' );
 
 		foreach ( $common_headers as $header => $value ) {
 			$headers[ $header ] = array( $header );

--- a/tests/class-test-plugin-headers.php
+++ b/tests/class-test-plugin-headers.php
@@ -2,10 +2,10 @@
 /**
  * Test Plugin Readme and PHP Headers
  *
- * @package PWCC\LocalTwemoji\Headers
+ * @package PWCC\LocalTwemoji\Tests
  */
 
-namespace PWCC\LocalTwemoji\Headers;
+namespace PWCC\LocalTwemoji\Tests;
 
 use WP_UnitTestCase;
 

--- a/tests/class-test-plugin-headers.php
+++ b/tests/class-test-plugin-headers.php
@@ -133,8 +133,8 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	 * @param string $header Header to test.
 	 */
 	public function test_required_readme_headers( $header ) {
-		$this->assertArrayHasKey( $header, self::$defined_readme_headers, "The readme file header {$header} is missing." );
-		$this->assertNotEmpty( self::$defined_readme_headers[ $header ], "The readme file header {$header} is empty." );
+		$this->assertArrayHasKey( $header, self::$defined_readme_headers, "The readme file header '{$header}' is missing." );
+		$this->assertNotEmpty( self::$defined_readme_headers[ $header ], "The readme file header '{$header}' is empty." );
 	}
 
 	/**
@@ -164,7 +164,7 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	 * @param string $header Header to test.
 	 */
 	public function test_forbidden_readme_headers( $header ) {
-		$this->assertArrayNotHasKey( $header, self::$defined_readme_headers, "The readme file header {$header} is forbidden." );
+		$this->assertArrayNotHasKey( $header, self::$defined_readme_headers, "The readme file header '{$header}' is forbidden." );
 	}
 
 	/**
@@ -194,8 +194,8 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	 * @param string $header Header to test.
 	 */
 	public function test_required_plugin_headers( $header ) {
-		$this->assertArrayHasKey( $header, self::$defined_plugin_headers, "The plugin file header {$header} is missing." );
-		$this->assertNotEmpty( self::$defined_plugin_headers[ $header ], "The readme file header {$header} is empty." );
+		$this->assertArrayHasKey( $header, self::$defined_plugin_headers, "The plugin file header '{$header}' is missing." );
+		$this->assertNotEmpty( self::$defined_plugin_headers[ $header ], "The readme file header '{$header}' is empty." );
 	}
 
 	/**
@@ -225,7 +225,7 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	 * @param string $header Header to test.
 	 */
 	public function test_forbidden_plugin_headers( $header ) {
-		$this->assertArrayNotHasKey( $header, self::$defined_plugin_headers, "The plugin file header {$header} is forbidden." );
+		$this->assertArrayNotHasKey( $header, self::$defined_plugin_headers, "The plugin file header '{$header}' is forbidden." );
 	}
 
 	/**
@@ -256,16 +256,22 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	 * @param string|null $readme_header_name Readme file header name to test. If null, the plugin header name will be used.
 	 */
 	public function test_common_headers_match( $plugin_header_name, $readme_header_name = null ) {
-		if ( empty( self::$defined_plugin_headers[ $plugin_header_name ] ) || empty( self::$defined_readme_headers[ $readme_header_name ?? $plugin_header_name ] ) ) {
+		$readme_header_name = $readme_header_name ?? $plugin_header_name;
+		if ( empty( self::$defined_plugin_headers[ $plugin_header_name ] ) || empty( self::$defined_readme_headers[ $readme_header_name ] ) ) {
 			// The header is not common to both files so the test passes.
 			$this->assertTrue( true );
 			return;
 		}
 
 		$plugin_header = self::$defined_plugin_headers[ $plugin_header_name ];
-		$readme_header = self::$defined_readme_headers[ $readme_header_name ?? $plugin_header_name ];
+		$readme_header = self::$defined_readme_headers[ $readme_header_name ];
 
-		$this->assertSame( $plugin_header, $readme_header, "The header {$plugin_header_name} does not match between the readme and plugin file." );
+		$message = "The header '{$plugin_header_name}' does not match between the readme and plugin file.";
+		if ( $plugin_header_name !== $readme_header_name ) {
+			$message = "The plugin header '{$plugin_header_name}' does not match the readme header '{$readme_header_name}'.";
+		}
+
+		$this->assertSame( $plugin_header, $readme_header, $message );
 	}
 
 	/**

--- a/tests/class-test-plugin-headers.php
+++ b/tests/class-test-plugin-headers.php
@@ -9,6 +9,10 @@ namespace PWCC\LocalTwemoji\Tests;
 
 use WP_UnitTestCase;
 
+const OPTIONAL  = 0;
+const REQUIRED  = 1;
+const FORBIDDEN = 2;
+
 /**
  * Test Plugin Readme and PHP Headers
  */
@@ -20,14 +24,27 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	 * @var string[] Headers defined in the readme spec. Key: Header, Value: true: required, false: optional.
 	 */
 	public static $readme_headers = array(
-		'Contributors'      => true,
-		'Donate link'       => false,
-		'Requires at least' => true, // Not required by the spec but I'm enforcing it.
-		'Tested up to'      => true,
-		'Stable tag'        => true,
-		'Requires PHP'      => false,
-		'License'           => true,
-		'License URI'       => false,
+		'Contributors'      => REQUIRED,
+		'Donate link'       => OPTIONAL,
+		'Requires at least' => REQUIRED, // Not required by the spec but I'm enforcing it.
+		'Tested up to'      => REQUIRED,
+		'Stable tag'        => REQUIRED,
+		'Requires PHP'      => OPTIONAL,
+		'License'           => REQUIRED,
+		'License URI'       => OPTIONAL,
+
+		// Plugin file headers that do not belong in the readme.
+		'Plugin Name'       => FORBIDDEN,
+		'Plugin URI'        => FORBIDDEN,
+		'Description'       => FORBIDDEN,
+		'Version'           => FORBIDDEN,
+		'Author'            => FORBIDDEN,
+		'Author URI'        => FORBIDDEN,
+		'Text Domain'       => FORBIDDEN,
+		'Domain Path'       => FORBIDDEN,
+		'Network'           => FORBIDDEN,
+		'Update URI'        => FORBIDDEN,
+		'Requires Plugins'  => FORBIDDEN,
 	);
 
 	/**
@@ -36,21 +53,27 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	 * @var string[] Headers defined in the plugin spec. Key: Header, Value: true: required, false: optional.
 	 */
 	public static $plugin_headers = array(
-		'Plugin Name'       => true,
-		'Plugin URI'        => false,
-		'Description'       => true,
-		'Version'           => true,
-		'Requires at least' => true, // Not required by the spec but I'm enforcing it.
-		'Requires PHP'      => true, // Not required by the spec but I'm enforcing it.
-		'Author'            => true,
-		'Author URI'        => false,
-		'License'           => true,
-		'License URI'       => false,
-		'Text Domain'       => false,
-		'Domain Path'       => false,
-		'Network'           => false,
-		'Update URI'        => false,
-		'Requires Plugins'  => false,
+		'Plugin Name'       => REQUIRED,
+		'Plugin URI'        => OPTIONAL,
+		'Description'       => REQUIRED,
+		'Version'           => REQUIRED,
+		'Requires at least' => REQUIRED, // Not required by the spec but I'm enforcing it.
+		'Requires PHP'      => REQUIRED, // Not required by the spec but I'm enforcing it.
+		'Author'            => REQUIRED,
+		'Author URI'        => OPTIONAL,
+		'License'           => REQUIRED,
+		'License URI'       => OPTIONAL,
+		'Text Domain'       => OPTIONAL,
+		'Domain Path'       => OPTIONAL,
+		'Network'           => OPTIONAL,
+		'Update URI'        => OPTIONAL,
+		'Requires Plugins'  => OPTIONAL,
+
+		// Readme file headers that do not belong in the plugin file.
+		'Contributors'      => FORBIDDEN,
+		'Donate link'       => FORBIDDEN,
+		'Tested up to'      => FORBIDDEN,
+		'Stable tag'        => FORBIDDEN,
 	);
 
 	/**
@@ -120,9 +143,44 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	 * @return array[] Data provider.
 	 */
 	public function data_required_readme_headers() {
-		$required_headers = array_filter( self::$readme_headers );
+		$required_headers = array_filter(
+			self::$readme_headers,
+			function ( $required ) {
+				return REQUIRED === $required;
+			}
+		);
 		$headers          = array();
 		foreach ( $required_headers as $header => $required ) {
+			$headers[ $header ] = array( $header );
+		}
+		return $headers;
+	}
+
+	/**
+	 * Test that the readme file does not have any forbidden headers.
+	 *
+	 * @dataProvider data_forbidden_readme_headers
+	 *
+	 * @param string $header Header to test.
+	 */
+	public function test_forbidden_readme_headers( $header ) {
+		$this->assertArrayNotHasKey( $header, self::$defined_readme_headers, "The readme file header {$header} is forbidden." );
+	}
+
+	/**
+	 * Data provider for test_forbidden_readme_headers.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_forbidden_readme_headers() {
+		$forbidden_headers = array_filter(
+			self::$readme_headers,
+			function ( $required ) {
+				return FORBIDDEN === $required;
+			}
+		);
+		$headers           = array();
+		foreach ( $forbidden_headers as $header => $required ) {
 			$headers[ $header ] = array( $header );
 		}
 		return $headers;
@@ -146,9 +204,44 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	 * @return array[] Data provider.
 	 */
 	public function data_required_plugin_headers() {
-		$required_headers = array_filter( self::$plugin_headers );
+		$required_headers = array_filter(
+			self::$plugin_headers,
+			function ( $required ) {
+				return REQUIRED === $required;
+			}
+		);
 		$headers          = array();
 		foreach ( $required_headers as $header => $required ) {
+			$headers[ $header ] = array( $header );
+		}
+		return $headers;
+	}
+
+	/**
+	 * Test that the plugin file does not have any forbidden headers.
+	 *
+	 * @dataProvider data_forbidden_plugin_headers
+	 *
+	 * @param string $header Header to test.
+	 */
+	public function test_forbidden_plugin_headers( $header ) {
+		$this->assertArrayNotHasKey( $header, self::$defined_plugin_headers, "The plugin file header {$header} is forbidden." );
+	}
+
+	/**
+	 * Data provider for test_forbidden_plugin_headers.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_forbidden_plugin_headers() {
+		$forbidden_headers = array_filter(
+			self::$plugin_headers,
+			function ( $required ) {
+				return FORBIDDEN === $required;
+			}
+		);
+		$headers           = array();
+		foreach ( $forbidden_headers as $header => $required ) {
 			$headers[ $header ] = array( $header );
 		}
 		return $headers;
@@ -163,13 +256,14 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	 * @param string|null $readme_header_name Readme file header name to test. If null, the plugin header name will be used.
 	 */
 	public function test_common_headers_match( $plugin_header_name, $readme_header_name = null ) {
-		$plugin_header = self::$defined_plugin_headers[ $plugin_header_name ];
-		$readme_header = self::$defined_readme_headers[ $readme_header_name ?? $plugin_header_name ];
-
-		if ( empty( $plugin_header ) || empty( $readme_header ) ) {
-			$this->markTestSkipped( "The header {$plugin_header_name} is not defined in both the readme and plugin file." );
+		if ( empty( self::$defined_plugin_headers[ $plugin_header_name ] ) || empty( self::$defined_readme_headers[ $readme_header_name ?? $plugin_header_name ] ) ) {
+			// The header is not common to both files so the test passes.
+			$this->assertTrue( true );
 			return;
 		}
+
+		$plugin_header = self::$defined_plugin_headers[ $plugin_header_name ];
+		$readme_header = self::$defined_readme_headers[ $readme_header_name ?? $plugin_header_name ];
 
 		$this->assertSame( $plugin_header, $readme_header, "The header {$plugin_header_name} does not match between the readme and plugin file." );
 	}

--- a/tests/class-test-plugin-headers.php
+++ b/tests/class-test-plugin-headers.php
@@ -157,18 +157,16 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	/**
 	 * Test that headers defined in both the readme and plugin file match.
 	 *
-	 * Note: This test will show as skipped if there are no common headers defined in
-	 * both the readme and plugin file. This is fine.
-	 *
 	 * @dataProvider data_common_headers_match
 	 *
-	 * @param string $header Header to test.
+	 * @param string      $plugin_header_name Plugin file header name to test.
+	 * @param string|null $readme_header_name Readme file header name to test. If null, the plugin header name will be used.
 	 */
-	public function test_common_headers_match( $header ) {
-		$plugin_header = self::$defined_plugin_headers[ $header ];
-		$readme_header = self::$defined_readme_headers[ $header ];
+	public function test_common_headers_match( $plugin_header_name, $readme_header_name = null ) {
+		$plugin_header = self::$defined_plugin_headers[ $plugin_header_name ];
+		$readme_header = self::$defined_readme_headers[ $readme_header_name ?? $plugin_header_name ];
 
-		$this->assertSame( $plugin_header, $readme_header, "The header {$header} does not match between the readme and plugin file." );
+		$this->assertSame( $plugin_header, $readme_header, "The header {$plugin_header_name} does not match between the readme and plugin file." );
 	}
 
 	/**
@@ -183,6 +181,9 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 		);
 
 		$headers = array();
+		// Always test the version matches the stable tag.
+		$headers[] = array( 'Version', 'Stable tag' );
+
 		foreach ( $common_headers as $header => $value ) {
 			$headers[ $header ] = array( $header );
 		}

--- a/tests/class-test-twemoji.php
+++ b/tests/class-test-twemoji.php
@@ -42,6 +42,24 @@ class Test_Twemoji extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the plugin version constant matches the file header.
+	 */
+	public function test_plugin_version_constant() {
+		$plugin_data = get_file_data(
+			__DIR__ . '/../local-twemoji.php',
+			array(
+				'Version' => 'Version',
+			)
+		);
+
+		$this->assertEquals(
+			\PWCC\LocalTwemoji\PLUGIN_VERSION,
+			$plugin_data['Version'],
+			'Plugin version constant should match the file header'
+		);
+	}
+
+	/**
 	 * Test the emoji URL filter.
 	 */
 	public function test_emoji_url_filter() {

--- a/tests/class-test-twemoji.php
+++ b/tests/class-test-twemoji.php
@@ -10,7 +10,7 @@ namespace PWCC\LocalTwemoji\Tests;
 use WP_UnitTestCase;
 
 /**
- * Sample Tests
+ * Test the Local Twemoji plugin.
  */
 class Test_Twemoji extends WP_UnitTestCase {
 	/**


### PR DESCRIPTION
Validates that the headers are correct in both the readme file and the main plugin file.