### PR TITLE
Use Twemoji version for cache busting

### DIFF
--- a/.github/version-bump-pr.md
+++ b/.github/version-bump-pr.md
@@ -6,6 +6,7 @@ Bot steps:
 
 * [x] Update `package.json` and `package-lock.json` with new version.
 * [x] Update images.
+* [x] Update `TWEMOJI_VERSION` constant in `namespace.php` file.
 
 Human steps:
 

--- a/bin/tw-version-update.sh
+++ b/bin/tw-version-update.sh
@@ -51,3 +51,13 @@ mv "$SCRIPT_DIR/../images/emoji/twemoji-$TWEMOJI_LATEST_RELEASE/assets/72x72" "$
 
 # Remove the downloaded directory
 rm -rf "$SCRIPT_DIR/../images/emoji/twemoji-$TWEMOJI_LATEST_RELEASE"
+
+# Update the version number in the namespace file.
+echo "Updating version in namespace file"
+NAMESPACE_FILE="$SCRIPT_DIR/../inc/namespace.php"
+if [ -f "$NAMESPACE_FILE" ]; then
+	sed -i.bak "s/const TWEMOJI_VERSION = '.*';/const TWEMOJI_VERSION = '$TWEMOJI_LATEST_RELEASE';/" "$NAMESPACE_FILE"
+	rm "$NAMESPACE_FILE.bak"
+else
+	echo "Warning: namespace.php file not found."
+fi

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -10,7 +10,8 @@
 
 namespace PWCC\LocalTwemoji;
 
-const PLUGIN_VERSION = '1.0.0';
+const PLUGIN_VERSION  = '1.0.0';
+const TWEMOJI_VERSION = '16.0.1';
 
 /**
  * Bootstrap the plugin.
@@ -49,15 +50,15 @@ function filter_emoji_svg_url() {
  * This is to ensure that browsers do not serve cached versions
  * of emoji images following an update to the plugin.
  *
- * The URL of the images does not change, so the plugin version
+ * The URL of the images does not change, so the Twemoji version
  * is appended as a query string parameter.
  *
  * @param string $ext The file extension of the emoji, either .svg or .png.
- * @return string The extension with the plugin version appended as a query string.
+ * @return string The extension with the Twemoji version appended as a query string.
  */
 function extension_cache_busting( $ext ) {
 	/*
-	 * Append the plugin version to the extension as a query string.
+	 * Append the Twemoji version to the extension as a query string.
 	 *
 	 * As the extension is not a full URL it's not possible to use
 	 * `sanitize_url()` here, so we use `sanitize_title()` to ensure
@@ -66,5 +67,5 @@ function extension_cache_busting( $ext ) {
 	 * - dots are converted to hyphens
 	 * - typos are converted/removed to ensure a valid string
 	 */
-	return $ext . '?ver=' . sanitize_title( PLUGIN_VERSION );
+	return $ext . '?ver=' . sanitize_title( TWEMOJI_VERSION );
 }

--- a/tests/class-test-twemoji.php
+++ b/tests/class-test-twemoji.php
@@ -29,6 +29,18 @@ class Test_Twemoji extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure the Twemoji version is correct.
+	 */
+	public function test_twemoji_version() {
+		$actual = \PWCC\LocalTwemoji\TWEMOJI_VERSION;
+
+		$packages = json_decode( file_get_contents( __DIR__ . '/../package.json' ), true );
+		$expected = $packages['devDependencies']['@twemoji/api'];
+
+		$this->assertSame( $expected, $actual, 'Twemoji version should match the version in package.json' );
+	}
+
+	/**
 	 * Test the emoji URL filter.
 	 */
 	public function test_emoji_url_filter() {

--- a/tests/class-test-twemoji.php
+++ b/tests/class-test-twemoji.php
@@ -34,6 +34,7 @@ class Test_Twemoji extends WP_UnitTestCase {
 	public function test_twemoji_version() {
 		$actual = \PWCC\LocalTwemoji\TWEMOJI_VERSION;
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- OK for this test.
 		$packages = json_decode( file_get_contents( __DIR__ . '/../package.json' ), true );
 		$expected = $packages['devDependencies']['@twemoji/api'];
 


### PR DESCRIPTION
Use the Twemoji version for the cache busting string rather than the plugin version.

This prevents unnecessary busting of caches when a plugin update is released without an update to the bundled version of Twemoji.