### PR TITLE
Modify requirements for Required versions headers, Tested up to header.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,8 @@
 === Local Twemoji ===
 Contributors: peterwilsoncc
 Tags: emoji, twemoji, performance
-Requires at least: 6.0
 Tested up to: 6.8
 Stable tag: 1.0.0
-Requires PHP: 7.4
 License: MIT
 License URI: https://github.com/peterwilsoncc/local-twemoji/?tab=MIT-1-ov-file
 

--- a/tests/class-test-plugin-headers.php
+++ b/tests/class-test-plugin-headers.php
@@ -21,7 +21,7 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	/**
 	 * Readme headers specification
 	 *
-	 * @var array<string,int> Headers defined in the readme spec. Key: Header, Value: true: required, false: optional.
+	 * @var array<string,int> Headers defined in the readme spec. Key: Header; Value: OPTIONAL, REQUIRED, FORBIDDEN.
 	 */
 	public static $readme_headers = array(
 		'Contributors'      => REQUIRED,
@@ -51,7 +51,7 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	/**
 	 * Plugin headers specification
 	 *
-	 * @var array<string,int> Headers defined in the plugin spec. Key: Header, Value: true: required, false: optional.
+	 * @var array<string,int> Headers defined in the plugin spec. Key: Header; Value: OPTIONAL, REQUIRED, FORBIDDEN.
 	 */
 	public static $plugin_headers = array(
 		'Plugin Name'       => REQUIRED,

--- a/tests/class-test-plugin-headers.php
+++ b/tests/class-test-plugin-headers.php
@@ -21,7 +21,7 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	/**
 	 * Readme headers specification
 	 *
-	 * @var string[] Headers defined in the readme spec. Key: Header, Value: true: required, false: optional.
+	 * @var array<string,int> Headers defined in the readme spec. Key: Header, Value: true: required, false: optional.
 	 */
 	public static $readme_headers = array(
 		'Contributors'      => REQUIRED,
@@ -51,7 +51,7 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 	/**
 	 * Plugin headers specification
 	 *
-	 * @var string[] Headers defined in the plugin spec. Key: Header, Value: true: required, false: optional.
+	 * @var array<string,int> Headers defined in the plugin spec. Key: Header, Value: true: required, false: optional.
 	 */
 	public static $plugin_headers = array(
 		'Plugin Name'       => REQUIRED,

--- a/tests/class-test-plugin-headers.php
+++ b/tests/class-test-plugin-headers.php
@@ -27,10 +27,8 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 		'Contributors'      => REQUIRED,
 		'Tags'              => OPTIONAL,
 		'Donate link'       => OPTIONAL,
-		'Requires at least' => REQUIRED, // Not required by the spec but I'm enforcing it.
 		'Tested up to'      => REQUIRED,
 		'Stable tag'        => REQUIRED,
-		'Requires PHP'      => OPTIONAL,
 		'License'           => REQUIRED,
 		'License URI'       => OPTIONAL,
 
@@ -45,6 +43,8 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 		'Domain Path'       => FORBIDDEN,
 		'Network'           => FORBIDDEN,
 		'Update URI'        => FORBIDDEN,
+		'Requires at least' => FORBIDDEN, // Both WP and the plugin directory prefer the version in the plugin file.
+		'Requires PHP'      => FORBIDDEN, // Both WP and the plugin directory prefer the version in the plugin file.
 		'Requires Plugins'  => FORBIDDEN,
 	);
 
@@ -74,8 +74,22 @@ class Test_Plugin_Headers extends WP_UnitTestCase {
 		'Contributors'      => FORBIDDEN,
 		'Tags'              => FORBIDDEN,
 		'Donate link'       => FORBIDDEN,
-		'Tested up to'      => FORBIDDEN,
 		'Stable tag'        => FORBIDDEN,
+
+		/*
+		 * Opinionated: Allowed by the spec.
+		 *
+		 * The WordPress plugin directory will use the plugin file headers if
+		 * it exists, and fall back to the readme file if it does not.
+		 *
+		 * However, the 10up Github Action for deploying updates to the
+		 * directory will require a version bump if the plugin file is
+		 * modified, so it's best to keep tested up to in the readme file.
+		 *
+		 * WordPress Core doesn't use the header, it pulls the data in
+		 * from the plugin API.
+		 */
+		'Tested up to'      => FORBIDDEN,
 	);
 
 	/**


### PR DESCRIPTION
Shuffles rules for where to place a few headers:

Plugin headers:
* Requires at least
* Requires PHP

Pulling these from the readme is bad as that can change without PHP file changes. The minimum versions can only change with PHP mods.

Readme headers:
* Tested up to
This can change without PHP changes so shouldn't be in the plugin file.