### PR TITLE
Remove GitHub readme.md from w.org release.

### DIFF
--- a/.github/workflows/wporg-assets-update.yml
+++ b/.github/workflows/wporg-assets-update.yml
@@ -8,7 +8,12 @@ jobs:
     name: Push asset update to WordPress.org
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - name: Checkout repository
+      uses: actions/checkout@master
+
+    - name: Remove readme.md from WordPress.org deploy.
+      run: rm -f readme.md
+
     - name: WordPress.org plugin asset/readme update
       uses: 10up/action-wordpress-plugin-asset-update@stable
       env:

--- a/.github/workflows/wporg-deploy.yml
+++ b/.github/workflows/wporg-deploy.yml
@@ -12,6 +12,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
+    - name: Remove readme.md from WordPress.org deploy.
+      run: rm -f readme.md
+
     - name: WordPress Plugin Deploy
       id: deploy
       uses: 10up/action-wordpress-plugin-deploy@stable


### PR DESCRIPTION
This prevents changes to the GitHub readme file from blocking deploys to WordPress.org readme and other asset updates.