### PR TITLE
Install SVN in own step in WP.org deploy actions.

### DIFF
--- a/.github/workflows/wporg-assets-update.yml
+++ b/.github/workflows/wporg-assets-update.yml
@@ -11,6 +11,18 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@master
 
+    - name: Install Subversion.
+      run: |
+        # Check if SVN is installed, if not install it.
+        if ! command -v svn &> /dev/null
+        then
+            sudo apt-get update -y
+            sudo apt-get install -y subversion
+        fi
+
+    - name: Create .wordpress-org directory if it doesn't exist.
+      run: mkdir -p .wordpress-org
+
     - name: Remove readme.md from WordPress.org deploy.
       run: |
         git rm readme.md

--- a/.github/workflows/wporg-deploy.yml
+++ b/.github/workflows/wporg-deploy.yml
@@ -12,12 +12,24 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
+    - name: Install Subversion.
+      run: |
+        # Check if SVN is installed, if not install it.
+        if ! command -v svn &> /dev/null
+        then
+            sudo apt-get update -y
+            sudo apt-get install -y subversion
+        fi
+
     - name: Remove readme.md from WordPress.org deploy.
       run: |
         git rm readme.md
         git config --global user.email "10upbot+github@10up.com"
         git config --global user.name "10upbot on GitHub"
         git commit -m "Remove readme.md for WordPress.org deploy"
+
+    - name: Create .wordpress-org directory if it doesn't exist.
+      run: mkdir -p .wordpress-org
 
     - name: WordPress Plugin Deploy
       id: deploy


### PR DESCRIPTION
This makes it all a little clearer by separating out the svn install and deploy steps.