### PR TITLE
Use NPM and gh-pages branch for updates to Twemoji

### DIFF
--- a/bin/tw-version-update.sh
+++ b/bin/tw-version-update.sh
@@ -67,4 +67,4 @@ else
 	echo "Warning: namespace.php file not found."
 fi
 
-git commit -am "Update Twemoji to $TWEMOJI_LATEST_RELEASE";
+git commit -am "Update Twemoji version number references to $TWEMOJI_LATEST_RELEASE";


### PR DESCRIPTION
Updates the build script to rely on the NPM release rather than the GitHub tag.

The GitHub tag is provided as a courtesy and may not be created when the package is updated on NPM. This change pulls images from the `gh-pages` branch via https://github-proxy.com. 

See https://github.com/jdecked/twemoji/issues/144
Fixes #61 