### PR TITLE
Replace gh proxy

### DIFF
--- a/bin/tw-version-update.sh
+++ b/bin/tw-version-update.sh
@@ -48,7 +48,7 @@ rm -rf "$SCRIPT_DIR/../images/emoji/twemoji-gh-pages"
 # Commit the image updates to git
 git add "$SCRIPT_DIR/../images/emoji/svg"
 git add "$SCRIPT_DIR/../images/emoji/72x72"
-git commit -am "Update Twemoji images to version $TWEMOJI_LATEST_RELEASE"
+git commit --allow-empty -am "Update Twemoji images to version $TWEMOJI_LATEST_RELEASE"
 
 # Remove the downloaded directory
 rm -rf "$SCRIPT_DIR/../images/emoji/twemoji-$TWEMOJI_LATEST_RELEASE"

--- a/bin/tw-version-update.sh
+++ b/bin/tw-version-update.sh
@@ -28,7 +28,7 @@ mkdir -p "$SCRIPT_DIR/../images/emoji/"
 echo "Updating to version $TWEMOJI_LATEST_RELEASE"
 
 # Download the images from the twemoji project
-curl -L -o "$SCRIPT_DIR/../images/emoji/twemoji-$TWEMOJI_LATEST_RELEASE.zip" "https://github-proxy.com/proxy/?repo=jdecked/twemoji&branch=gh-pages&directory=v/$TWEMOJI_LATEST_RELEASE"
+curl -L -o "$SCRIPT_DIR/../images/emoji/twemoji-$TWEMOJI_LATEST_RELEASE.zip" "https://github.com/jdecked/twemoji/archive/refs/heads/gh-pages.zip"
 
 # Unzip the downloaded file
 unzip "$SCRIPT_DIR/../images/emoji/twemoji-$TWEMOJI_LATEST_RELEASE.zip" -d "$SCRIPT_DIR/../images/emoji/"
@@ -37,13 +37,13 @@ unzip "$SCRIPT_DIR/../images/emoji/twemoji-$TWEMOJI_LATEST_RELEASE.zip" -d "$SCR
 rm "$SCRIPT_DIR/../images/emoji/twemoji-$TWEMOJI_LATEST_RELEASE.zip"
 
 # Move the SVG images to the correct directory
-mv "$SCRIPT_DIR/../images/emoji/v/$TWEMOJI_LATEST_RELEASE/svg" "$SCRIPT_DIR/../images/emoji/"
+mv "$SCRIPT_DIR/../images/emoji/twemoji-gh-pages/v/$TWEMOJI_LATEST_RELEASE/svg" "$SCRIPT_DIR/../images/emoji/"
 
 # Move the PNG images to the correct directory.
-mv "$SCRIPT_DIR/../images/emoji/v/$TWEMOJI_LATEST_RELEASE/72x72" "$SCRIPT_DIR/../images/emoji/"
+mv "$SCRIPT_DIR/../images/emoji/twemoji-gh-pages/v/$TWEMOJI_LATEST_RELEASE/72x72" "$SCRIPT_DIR/../images/emoji/"
 
 # Remove the unzipped directory
-rm -rf "$SCRIPT_DIR/../images/emoji/v"
+rm -rf "$SCRIPT_DIR/../images/emoji/twemoji-gh-pages"
 
 # Commit the image updates to git
 git add "$SCRIPT_DIR/../images/emoji/svg"


### PR DESCRIPTION
* Download Twemoji imges from GH now github-proxy.com is deprecated.
* Fix an issue with the script to allow empty commits of images as they may not have changed following a script only update.